### PR TITLE
Revert "Change submodules url to relative-path for greater 'clone' flexibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libseccomp"]
 	path = libseccomp
-	url = ../libseccomp.git
+	url = git@github.com:nestybox/libseccomp.git
 [submodule "libseccomp-golang"]
 	path = libseccomp-golang
-	url = ../libseccomp-golang.git
+	url = git@github.com:nestybox/libseccomp-golang.git


### PR DESCRIPTION
This reverts commit 7b9ca3b36f8f99deb65613e35cd84c3fa0bef261.

Unfortunately, even though recursive git-clone operation works as expected with submodule's relative-path, Github portal is not properly handling this feature and, thereby, submodules are not reachable through Github's UI.

This Github issue is being tracked here: https://github.community/t/support-linking-relative-urls-on-submodules/2078

Signed-off-by: Rodny Molina <rmolina@nestybox.com>