### PR TITLE
First commit of the sysbox formatter package.

### DIFF
--- a/formatter/containerID.go
+++ b/formatter/containerID.go
@@ -1,0 +1,19 @@
+package formatter
+
+import "github.com/docker/docker/pkg/stringid"
+
+type ContainerID struct {
+	ID string
+}
+
+func (cid ContainerID) ShortID() string {
+	return stringid.TruncateID(cid.ID)
+}
+
+func (cid ContainerID) LongID() string {
+	return cid.ID
+}
+
+func (cid ContainerID) String() string {
+	return cid.ShortID()
+}

--- a/formatter/go.mod
+++ b/formatter/go.mod
@@ -1,0 +1,3 @@
+module github.com/nestybox/sysbox-libs/formatter
+
+go 1.14


### PR DESCRIPTION
This package provides utilities to format output created by sysbox (e.g., in the sysbox logs).

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>