### PR TITLE
Add Linux Kernel header path for Arch Linux

### DIFF
--- a/utils/linux.go
+++ b/utils/linux.go
@@ -156,6 +156,8 @@ func GetLinuxHeaderPath(distro string) (string, error) {
 
 	if distro == "redhat" || distro == "centos" || distro == "fedora" {
 		path = filepath.Join("/usr/src/kernels", kernelRel)
+	} else if distro == "arch" {
+		path = filepath.Join("/lib/modules", kernelRel, "build")
 	} else {
 		// All other distros appear to be following the "/usr/src/linux-headers-rel"
 		// naming convention.


### PR DESCRIPTION
The kernel headers for Arch Linux are stored in /lib/modules/$(uname -r)/build

(Unlike other common distributions such as Alpine, Debian, Ubuntu, CentOS, Fedora, etc., /lib/modules/$(uname -r)/build is not a symlink, but the actual directory where the headers are stored.)

For good usability on Arch Linux, the related commit "Create intermediate paths when symlinking Linux kernel headers" on sysbox-mgr also needs to be merged since otherwise, a lot of images (specially Alpine-based ones) fail to launch.

This only adds the header path on the runtime code, not on the build code, since Sysbox does not need to be built on Arch (the Debian binaries work).