### PR TITLE
Add support for AlmaLinux and Rocky Linux

### DIFF
--- a/utils/linux.go
+++ b/utils/linux.go
@@ -222,7 +222,7 @@ func GetLinuxHeaderPath(distro string) (string, error) {
 		return "", err
 	}
 
-	if distro == "redhat" || distro == "centos" || distro == "fedora" {
+	if distro == "redhat" || distro == "centos" || distro == "rocky" || distro == "almalinux" || distro == "fedora" {
 		path = filepath.Join("/usr/src/kernels", kernelRel)
 	} else if distro == "arch" || distro == "flatcar" {
 		path = filepath.Join("/lib/modules", kernelRel, "build")


### PR DESCRIPTION
Add support for AlmaLinux and Rocky Linux as supported OSes to handle the linux kernel headers properly 

Closes #471

Signed-off-by: Christos Roussidis <xristos.roussidis@gmail.com>