### PR TITLE
Add btrfs to list ID-mapped mount black list.

### DIFF
--- a/idShiftUtils/idMapMount.go
+++ b/idShiftUtils/idMapMount.go
@@ -62,6 +62,7 @@ import (
 var idMapMountFsBlackList = []int64{
 	unix.OVERLAYFS_SUPER_MAGIC,
 	unix.TMPFS_MAGIC,
+	unix.BTRFS_SUPER_MAGIC,
 }
 
 var idMapMountDevBlackList = []string{"/dev/null"}


### PR DESCRIPTION
ID-mapped mounts are not yet supported on btrfs (i.e., they fail with "invalid
argument: unknown").

I found this out while testing Sysbox on a Fedora-35 cloud image which uses
btrfs as it's default filesystem.

Without this change, Sysbox will not work on btrfs-based hosts as
container creation will fail when Sysbox tries to ID-map-mount
host files backed by btrfs.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>