### PR TITLE
Add IDMappedMountOrShiftfs constant to idShiftUtils.

### DIFF
--- a/idShiftUtils/idShiftUtils.go
+++ b/idShiftUtils/idShiftUtils.go
@@ -39,6 +39,7 @@ const (
 	NoShift IDShiftType = iota
 	Shiftfs
 	IDMappedMount
+	IDMappedMountOrShiftfs
 	Chown
 )
 


### PR DESCRIPTION
This is needed for a change in sysbox-runc that causes Sysbox
to use shiftfs in case idmapped-mounts don't work.

Signed-off-by: Cesar Talledo <cesar.talledo@docker.com>