### PR TITLE
Add FUSE to ID-mapped-mounts blacklist.

### DIFF
--- a/idShiftUtils/idMapMount.go
+++ b/idShiftUtils/idMapMount.go
@@ -64,6 +64,7 @@ var idMapMountFsBlackList = []int64{
 	unix.OVERLAYFS_SUPER_MAGIC,
 	unix.TMPFS_MAGIC,
 	unix.BTRFS_SUPER_MAGIC,
+	0x65735546, // unix.FUSE_SUPER_MAGIC
 }
 
 var idMapMountDevBlackList = []string{"/dev/null"}


### PR DESCRIPTION
Some FUSE-backed filesystems (e.g. virtiofs) don't work with ID-mapped-mount yet. Add them to the blacklist.

Signed-off-by: Cesar Talledo <cesar.talledo@docker.com>