### PR TITLE
Skip ID-mapped-mounts on Docker Desktop's fakeowner-fs.

### DIFF
--- a/idShiftUtils/idMapMount.go
+++ b/idShiftUtils/idMapMount.go
@@ -65,6 +65,7 @@ var idMapMountFsBlackList = []int64{
 	unix.TMPFS_MAGIC,
 	unix.BTRFS_SUPER_MAGIC,
 	0x65735546, // unix.FUSE_SUPER_MAGIC
+	0x6a656a63, // FAKEOWNER (Docker Desktop's Linux VM only)
 }
 
 var idMapMountDevBlackList = []string{"/dev/null"}


### PR DESCRIPTION
ID-mapped-mounts are not yet supported on fakeowner-fs, so skip them for now.

Signed-off-by: Cesar Talledo <cesar.talledo@docker.com>