### PR TITLE
capability package: add support for OCI capability formating.

### DIFF
--- a/capability/capability.go
+++ b/capability/capability.go
@@ -44,6 +44,13 @@ const (
 	AMBS   = AMBIENT
 )
 
+type CapFormat uint
+
+const (
+	STRING CapFormat = iota
+	OCI_STRING
+)
+
 //go:generate go run enumgen/gen.go
 type Cap int
 
@@ -395,6 +402,94 @@ func (c Cap) String() string {
 	return "unknown"
 }
 
+func (c Cap) OCIString() string {
+	switch c {
+	case CAP_CHOWN:
+		return "CAP_CHOWN"
+	case CAP_DAC_OVERRIDE:
+		return "CAP_DAC_OVERRIDE"
+	case CAP_DAC_READ_SEARCH:
+		return "CAP_DAC_READ_SEARCH"
+	case CAP_FOWNER:
+		return "CAP_FOWNER"
+	case CAP_FSETID:
+		return "CAP_FSETID"
+	case CAP_KILL:
+		return "CAP_KILL"
+	case CAP_SETGID:
+		return "CAP_SETGID"
+	case CAP_SETUID:
+		return "CAP_SETUID"
+	case CAP_SETPCAP:
+		return "CAP_SETPCAP"
+	case CAP_LINUX_IMMUTABLE:
+		return "CAP_LINUX_IMMUTABLE"
+	case CAP_NET_BIND_SERVICE:
+		return "CAP_NET_BIND_SERVICE"
+	case CAP_NET_BROADCAST:
+		return "CAP_NET_BROADCAST"
+	case CAP_NET_ADMIN:
+		return "CAP_NET_ADMIN"
+	case CAP_NET_RAW:
+		return "CAP_NET_RAW"
+	case CAP_IPC_LOCK:
+		return "CAP_IPC_LOCK"
+	case CAP_IPC_OWNER:
+		return "CAP_IPC_OWNER"
+	case CAP_SYS_MODULE:
+		return "CAP_SYS_MODULE"
+	case CAP_SYS_RAWIO:
+		return "CAP_SYS_RAWIO"
+	case CAP_SYS_CHROOT:
+		return "CAP_SYS_CHROOT"
+	case CAP_SYS_PTRACE:
+		return "CAP_SYS_PTRACE"
+	case CAP_SYS_PACCT:
+		return "CAP_SYS_PACCT"
+	case CAP_SYS_ADMIN:
+		return "CAP_SYS_ADMIN"
+	case CAP_SYS_BOOT:
+		return "CAP_SYS_BOOT"
+	case CAP_SYS_NICE:
+		return "CAP_SYS_NICE"
+	case CAP_SYS_RESOURCE:
+		return "CAP_SYS_RESOURCE"
+	case CAP_SYS_TIME:
+		return "CAP_SYS_TIME"
+	case CAP_SYS_TTY_CONFIG:
+		return "CAP_SYS_TTY_CONFIG"
+	case CAP_MKNOD:
+		return "CAP_MKNOD"
+	case CAP_LEASE:
+		return "CAP_LEASE"
+	case CAP_AUDIT_WRITE:
+		return "CAP_AUDIT_WRITE"
+	case CAP_AUDIT_CONTROL:
+		return "CAP_AUDIT_CONTROL"
+	case CAP_SETFCAP:
+		return "CAP_SETFCAP"
+	case CAP_MAC_OVERRIDE:
+		return "CAP_MAC_OVERRIDE"
+	case CAP_MAC_ADMIN:
+		return "CAP_MAC_ADMIN"
+	case CAP_SYSLOG:
+		return "CAP_SYSLOG"
+	case CAP_WAKE_ALARM:
+		return "CAP_WAKE_ALARM"
+	case CAP_BLOCK_SUSPEND:
+		return "CAP_BLOCK_SUSPEND"
+	case CAP_AUDIT_READ:
+		return "CAP_AUDIT_READ"
+	case CAP_PERFMON:
+		return "CAP_PERFMON"
+	case CAP_BPF:
+		return "CAP_BPF"
+	case CAP_CHECKPOINT_RESTORE:
+		return "CAP_CHECKPOINT_RESTORE"
+	}
+	return "unknown"
+}
+
 // List returns list of all supported capabilities
 func List() []Cap {
 	return []Cap{
@@ -478,13 +573,13 @@ type Capabilities interface {
 	// BOUNDS or AMBS.
 	Clear(kind CapType)
 
-	// String return current capabilities state of the given capabilities
+	// StringCap returns current capabilities state of the given capabilities
 	// set as string. The 'which' value should be one of EFFECTIVE,
 	// PERMITTED, INHERITABLE BOUNDING or AMBIENT
-	StringCap(which CapType) string
+	StringCap(which CapType, format CapFormat) string
 
 	// String return current capabilities state as string.
-	String() string
+	String(format CapFormat) string
 
 	// Load load actual capabilities value. This will overwrite all
 	// outstanding changes.

--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -84,7 +84,7 @@ func initLastCap() error {
 	return nil
 }
 
-func mkStringCap(c Capabilities, which CapType) (ret string) {
+func mkStringCap(c Capabilities, which CapType, format CapFormat) (ret string) {
 	for i, first := Cap(0), true; i <= CAP_LAST_CAP; i++ {
 		if !c.Get(which, i) {
 			continue
@@ -94,12 +94,16 @@ func mkStringCap(c Capabilities, which CapType) (ret string) {
 		} else {
 			ret += ", "
 		}
-		ret += i.String()
+		if format == OCI_STRING {
+			ret += i.OCIString()
+		} else {
+			ret += i.String()
+		}
 	}
 	return
 }
 
-func mkString(c Capabilities, max CapType) (ret string) {
+func mkString(c Capabilities, max CapType, format CapFormat) (ret string) {
 	ret = "{"
 	for i := CapType(1); i <= max; i <<= 1 {
 		ret += " " + i.String() + "=\""
@@ -108,7 +112,7 @@ func mkString(c Capabilities, max CapType) (ret string) {
 		} else if c.Full(i) {
 			ret += "full"
 		} else {
-			ret += c.StringCap(i)
+			ret += c.StringCap(i, format)
 		}
 		ret += "\""
 	}
@@ -347,12 +351,12 @@ func (c *capsV3) Clear(kind CapType) {
 	}
 }
 
-func (c *capsV3) StringCap(which CapType) (ret string) {
-	return mkStringCap(c, which)
+func (c *capsV3) StringCap(which CapType, format CapFormat) (ret string) {
+	return mkStringCap(c, which, format)
 }
 
-func (c *capsV3) String() (ret string) {
-	return mkString(c, BOUNDING)
+func (c *capsV3) String(format CapFormat) (ret string) {
+	return mkString(c, BOUNDING, format)
 }
 
 func (c *capsV3) LoadOriginal() (err error) {
@@ -614,12 +618,12 @@ func (c *capsFile) Clear(kind CapType) {
 	}
 }
 
-func (c *capsFile) StringCap(which CapType) (ret string) {
-	return mkStringCap(c, which)
+func (c *capsFile) StringCap(which CapType, format CapFormat) (ret string) {
+	return mkStringCap(c, which, format)
 }
 
-func (c *capsFile) String() (ret string) {
-	return mkString(c, INHERITABLE)
+func (c *capsFile) String(format CapFormat) (ret string) {
+	return mkString(c, INHERITABLE, format)
 }
 
 func (c *capsFile) Load() (err error) {


### PR DESCRIPTION
This allows users of the package to obtain the list of capabilities for a process using OCI capability format (e.g., "CAP_CHOWN") as opposed to the standard format (e.g., "chown").