### PR TITLE
Prevent golang deadlock detection in runIDMapMountCheckOnHost().

### DIFF
--- a/idMap/idMapMount.go
+++ b/idMap/idMapMount.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/nestybox/sysbox-libs/linuxUtils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -177,9 +178,8 @@ func runIDMapMountCheckOnHost(dir string, checkOnOverlayfs bool) (bool, error) {
 
 	// Create a userns process that simply pauses until killed
 	execFunc := func() {
-		for {
-			c := make(chan struct{})
-			<-c
+		for i := 0; i < 3600; i++ {
+			time.Sleep(1 * time.Second)
 		}
 	}
 


### PR DESCRIPTION
Small change to prevent golang runtime from getting confused into thinking that there is a deadlock in runIDMapMountCheckOnHost().

Without this change, Golang 1.19+ was sporadically complaining as follows:

"Starting sysbox-mgr
fatal error: all goroutines are asleep - deadlock!"

This occurs because runIDMapMountCheckOnHost() forks a process into a user-ns that sleeps forver, and then kills the process and waits for it to exit. During this wait, there is a window of time where all goroutines are waiting (though not forever), and this causes the golang runtime to get confused into thinking there is a deadlock.

This commit fixes this.