### PR TITLE
Remove btrfs from ID-map blacklist.

### DIFF
--- a/idMap/idMapMount.go
+++ b/idMap/idMapMount.go
@@ -41,7 +41,6 @@ import (
 
 var idMapMountFsBlackList = []int64{
 	unix.TMPFS_MAGIC,
-	unix.BTRFS_SUPER_MAGIC,
 	unix.OVERLAYFS_SUPER_MAGIC,
 	0x65735546, // unix.FUSE_SUPER_MAGIC
 	0x6a656a63, // FAKEOWNER (Docker Desktop's Linux VM only)


### PR DESCRIPTION
ID-mapped mounts on top of BTRFS are supported in Linux kernel 5.15+.

See: https://kernelnewbies.org/Linux_5.15#Btrfs_support_for_fs-verity_and_id_mapping