### PR TITLE
First commit of file monitor.

### DIFF
--- a/fileMonitor/fileMon.go
+++ b/fileMonitor/fileMon.go
@@ -1,0 +1,96 @@
+//
+// Copyright 2023 Nestybox Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// The fileMonitor notifies the caller about file removal events.
+// It uses a simple polling algorithm.
+
+package fileMonitor
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Cfg struct {
+	EventBufSize int
+	PollInterval time.Duration // in milliseconds
+}
+
+// polling config limits
+const (
+	PollMin = 1 * time.Millisecond
+	PollMax = 10000 * time.Millisecond
+)
+
+type Event struct {
+	Filename string
+	Err      error
+}
+
+type FileMon struct {
+	mu         sync.Mutex
+	cfg        Cfg
+	eventTable map[string]bool
+	cmdCh      chan cmd
+	eventCh    chan []Event // receives events from monitor thread
+}
+
+func New(cfg *Cfg) (*FileMon, error) {
+	if err := validateCfg(cfg); err != nil {
+		return nil, err
+	}
+
+	fm := &FileMon{
+		cfg:        *cfg,
+		eventTable: make(map[string]bool),
+		cmdCh:      make(chan cmd),
+		eventCh:    make(chan []Event, cfg.EventBufSize),
+	}
+
+	go fileMon(fm)
+
+	return fm, nil
+}
+
+func (fm *FileMon) Add(file string) {
+	fm.mu.Lock()
+	fm.eventTable[file] = true
+	fm.mu.Unlock()
+}
+
+func (fm *FileMon) Remove(file string) {
+	fm.mu.Lock()
+	if _, ok := fm.eventTable[file]; ok {
+		delete(fm.eventTable, file)
+	}
+	fm.mu.Unlock()
+}
+
+func (fm *FileMon) Events() <-chan []Event {
+	return fm.eventCh
+}
+
+func (fm *FileMon) Close() {
+	fm.cmdCh <- stop
+}
+
+func validateCfg(cfg *Cfg) error {
+	if cfg.PollInterval < PollMin || cfg.PollInterval > PollMax {
+		return fmt.Errorf("invalid config: poll interval must be in range [%d, %d]; found %d", PollMin, PollMax, cfg.PollInterval)
+	}
+	return nil
+}

--- a/fileMonitor/fileMon_test.go
+++ b/fileMonitor/fileMon_test.go
@@ -1,0 +1,341 @@
+//
+// Copyright 2023 Nestybox Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package fileMonitor
+
+import (
+	"fmt"
+	"github.com/nestybox/sysbox-libs/utils"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func init() {
+	//log.SetLevel(log.DebugLevel)
+}
+
+func TestOneRemovalPerInterval(t *testing.T) {
+
+	numFiles := 5
+
+	// create a bunch of temp files
+	tmpFiles := []string{}
+	for i := 0; i < numFiles; i++ {
+		file, err := ioutil.TempFile("", "fileMonTest")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file.Name())
+		tmpFiles = append(tmpFiles, file.Name())
+		t.Logf("Created file %s", file.Name())
+	}
+
+	// create a new file mon
+	pollInterval := 100 * time.Millisecond
+	cfg := Cfg{
+		EventBufSize: 10,
+		PollInterval: pollInterval,
+	}
+	fm, err := New(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// watch files
+	for _, file := range tmpFiles {
+		fm.Add(file)
+	}
+	fileEvents := fm.Events()
+
+	// remove one file at a time (one per poll interval)
+	for _, file := range tmpFiles {
+		if err := os.Remove(file); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("Removed file %s", file)
+		time.Sleep(pollInterval)
+		events := <-fileEvents
+		if len(events) != 1 {
+			t.Fatalf("incorrect events list size: want 1, got %d (%+v)", len(events), events)
+		}
+		e := events[0]
+		if e.Filename != file {
+			t.Fatalf("incorrect event file name: want %s, got %s", file, e.Filename)
+		}
+		if e.Err != nil {
+			t.Fatalf("event has error: %s", e.Err)
+		}
+		t.Logf("OK: got event for file %s", e.Filename)
+	}
+
+	fm.Close()
+	log.Debugf("Done.")
+}
+
+func TestMultiRemovalPerInterval(t *testing.T) {
+
+	numFiles := 5
+
+	// create a bunch of temp files
+	tmpFiles := []string{}
+	for i := 0; i < numFiles; i++ {
+		file, err := ioutil.TempFile("", "fileMonTest")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file.Name())
+		tmpFiles = append(tmpFiles, file.Name())
+		t.Logf("Created file %s", file.Name())
+	}
+
+	// create a new file mon
+	pollInterval := 100 * time.Millisecond
+	cfg := Cfg{
+		EventBufSize: 10,
+		PollInterval: pollInterval,
+	}
+	fm, err := New(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// watch files
+	for _, file := range tmpFiles {
+		fm.Add(file)
+	}
+	fileEvents := fm.Events()
+
+	// remove all files in a single poll interval
+	time.Sleep(pollInterval)
+
+	for _, file := range tmpFiles {
+		if err := os.Remove(file); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("Removed file %s", file)
+	}
+
+	// verify we got all events
+	time.Sleep(2 * pollInterval)
+
+	events := []Event{}
+	for {
+		events = append(events, <-fileEvents...)
+		numEvents := len(events)
+		if numEvents == numFiles {
+			break
+		} else if numEvents > numFiles {
+			t.Fatalf("got more file removal events than files (want %d, got %d)", numFiles, numEvents)
+		}
+	}
+
+	for _, e := range events {
+		if !utils.StringSliceContains(tmpFiles, e.Filename) {
+			t.Fatalf("event %+v does not match a removed file", e)
+		}
+		if e.Err != nil {
+			t.Fatalf("event has error: %s", e.Err)
+		}
+		t.Logf("OK: got event for file %s", e.Filename)
+	}
+
+	fm.Close()
+}
+
+func TestSymlinkedFileRemoval(t *testing.T) {
+
+	numFiles := 5
+	tmpFiles := []string{}
+	symlinks := []string{}
+
+	// create a bunch of temp files with symlinks to them
+	for i := 0; i < numFiles; i++ {
+		file, err := ioutil.TempFile("", "fileMonTest")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file.Name())
+
+		// create symlink to file
+		link := fmt.Sprintf("symlink%d", i)
+		if err := os.Symlink(file.Name(), link); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(link)
+
+		tmpFiles = append(tmpFiles, file.Name())
+		symlinks = append(symlinks, link)
+		t.Logf("Created file %s and symlink %s", file.Name(), link)
+	}
+
+	// create a new file mon
+	pollInterval := 100 * time.Millisecond
+	cfg := Cfg{
+		EventBufSize: 10,
+		PollInterval: pollInterval,
+	}
+	fm, err := New(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// watch the symlinks
+	for _, file := range symlinks {
+		fm.Add(file)
+	}
+	fileEvents := fm.Events()
+
+	// remove one file at a time, verify we get the event
+	for i := 0; i < numFiles; i++ {
+		file := tmpFiles[i]
+		link := symlinks[i]
+
+		if err := os.Remove(file); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("Removed file %s", file)
+		time.Sleep(pollInterval)
+		events := <-fileEvents
+		if len(events) != 1 {
+			t.Fatalf("incorrect events list size: want 1, got %d (%+v)", len(events), events)
+		}
+		e := events[0]
+		if e.Filename != link {
+			t.Fatalf("incorrect event file name: want %s, got %s", link, e.Filename)
+		}
+		if e.Err != nil {
+			t.Fatalf("event has error: %s", e.Err)
+		}
+		t.Logf("OK: got event for file %s", e.Filename)
+	}
+
+	fm.Close()
+	log.Debugf("Done.")
+}
+
+func TestEventRemoval(t *testing.T) {
+
+	numFiles := 5
+
+	// create a bunch of temp files
+	tmpFiles := []string{}
+	for i := 0; i < numFiles; i++ {
+		file, err := ioutil.TempFile("", "fileMonTest")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file.Name())
+		tmpFiles = append(tmpFiles, file.Name())
+		t.Logf("Created file %s", file.Name())
+	}
+
+	// create a new file mon
+	pollInterval := 100 * time.Millisecond
+	cfg := Cfg{
+		EventBufSize: 10,
+		PollInterval: pollInterval,
+	}
+	fm, err := New(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// watch files
+	for _, file := range tmpFiles {
+		fm.Add(file)
+	}
+	fileEvents := fm.Events()
+
+	// remove event for last file
+	last := len(tmpFiles) - 1
+	lastFile := tmpFiles[last]
+	fm.Remove(lastFile)
+
+	// Remove all files
+	for _, file := range tmpFiles {
+		if err := os.Remove(file); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("Removed file %s", file)
+	}
+
+	// Verify notification was received for all files, except the last file
+	time.Sleep(2 * pollInterval)
+
+	events := []Event{}
+	for {
+		events = append(events, <-fileEvents...)
+		numEvents := len(events)
+		if numEvents == numFiles-1 {
+			break
+		} else if numEvents > numFiles-1 {
+			t.Fatalf("got more file removal events than files (want %d, got %d)", numFiles-1, numEvents)
+		}
+	}
+
+	for _, e := range events {
+		if e.Filename == lastFile {
+			t.Fatalf("event %+v should not have been received", e)
+		}
+		if !utils.StringSliceContains(tmpFiles, e.Filename) {
+			t.Fatalf("event %+v does not match a removed file", e)
+		}
+		if e.Err != nil {
+			t.Fatalf("event has error: %s", e.Err)
+		}
+		t.Logf("OK: got event for file %s", e.Filename)
+	}
+}
+
+func TestEventOnNonExistentFile(t *testing.T) {
+
+	// create a new file mon
+	pollInterval := 100 * time.Millisecond
+	cfg := Cfg{
+		EventBufSize: 10,
+		PollInterval: pollInterval,
+	}
+	fm, err := New(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Watch a non-existent file
+	file := "/tmp/__doesnotexist__"
+	fm.Add(file)
+
+	// Should return event indicating file does not exist
+	events := <-fm.Events()
+
+	if len(events) != 1 {
+		t.Fatalf("incorrect number of events; want 1, got %d (%+v)", len(events), events)
+	}
+
+	e := events[0]
+
+	if e.Err != nil {
+		t.Fatalf("event has error: %v", err)
+	}
+
+	if e.Filename != file {
+		t.Fatalf("incorrect event filename: want %s, got %s", file, e.Filename)
+	}
+
+	fm.Close()
+}

--- a/fileMonitor/go.mod
+++ b/fileMonitor/go.mod
@@ -1,0 +1,15 @@
+module github.com/nestybox/sysbox-libs/fileMonitor
+
+go 1.18
+
+require (
+	github.com/nestybox/sysbox-libs/utils v0.0.0-00010101000000-000000000000
+	github.com/sirupsen/logrus v1.9.1
+)
+
+require (
+	github.com/opencontainers/runtime-spec v1.0.2 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+)
+
+replace github.com/nestybox/sysbox-libs/utils => ../utils

--- a/fileMonitor/go.sum
+++ b/fileMonitor/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/opencontainers/runtime-spec v1.0.2 h1:UfAcuLBJB9Coz72x1hgl8O5RVzTdNiaglX6v2DM6FI0=
+github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.1 h1:Ou41VVR3nMWWmTiEUnj0OlsgOSCUFgsPAOl6jRIcVtQ=
+github.com/sirupsen/logrus v1.9.1/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/fileMonitor/monitor.go
+++ b/fileMonitor/monitor.go
@@ -1,0 +1,94 @@
+//
+// Copyright 2023 Nestybox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package fileMonitor
+
+import (
+	"os"
+	"time"
+)
+
+type cmd int
+
+const (
+	stop cmd = iota
+)
+
+// Monitors files associated with the given FileMon instance
+func fileMon(fm *FileMon) {
+	for {
+		eventList := []Event{}
+		rmList := []Event{}
+
+		// handle incoming commands first
+		select {
+		case cmd := <-fm.cmdCh:
+			if cmd == stop {
+				fm.eventCh <- eventList
+				return
+			}
+		default:
+		}
+
+		// perform monitoring action
+		fm.mu.Lock()
+		for filename, _ := range fm.eventTable {
+			exists, err := checkFileExists(filename)
+			if err != nil || !exists {
+				eventList = append(eventList, Event{
+					Filename: filename,
+					Err:      err,
+				})
+
+				// file removal implies event won't hit again; remove it.
+				rmList = append(rmList, Event{filename, nil})
+			}
+		}
+
+		// release the lock so that we don't hold it while sending the event list
+		// (in case the event channel is blocked); this way new events can
+		// continue to be added.
+		fm.mu.Unlock()
+
+		// send event list
+		if len(eventList) > 0 {
+			fm.eventCh <- eventList
+		}
+
+		// remove events that won't hit any more
+		fm.mu.Lock()
+		for _, e := range rmList {
+			if _, ok := fm.eventTable[e.Filename]; ok {
+				delete(fm.eventTable, e.Filename)
+			}
+		}
+		fm.mu.Unlock()
+
+		// wait for the poll period
+		time.Sleep(fm.cfg.PollInterval)
+	}
+}
+
+// Checks if the given file exists
+func checkFileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
The file monitor allows callers to get notified about file removal events. It uses a simple polling algorithm and provides an alternative to event-based notifiers (e.g., fsnotify).