### PR TITLE
Add containerd utils to sysbox-libs.

### DIFF
--- a/capability/capability_test.go
+++ b/capability/capability_test.go
@@ -55,7 +55,6 @@ func TestState(t *testing.T) {
 		sets CapType
 		max  Cap
 	}{
-		{"v1", new(capsV1), EFFECTIVE | PERMITTED, CAP_AUDIT_CONTROL},
 		{"v3", new(capsV3), EFFECTIVE | PERMITTED | BOUNDING, CAP_LAST_CAP},
 		{"file_v1", new(capsFile), EFFECTIVE | PERMITTED, CAP_AUDIT_CONTROL},
 		{"file_v2", capf, EFFECTIVE | PERMITTED, CAP_LAST_CAP},

--- a/containerdUtils/containerdUtils.go
+++ b/containerdUtils/containerdUtils.go
@@ -1,0 +1,66 @@
+//
+// Copyright: (C) 2024 Nestybox Inc.  All rights reserved.
+//
+package containerdUtils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Location of containerd config file
+// (see https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md)
+var (
+	configPath = []string{
+		"/etc/containerd/containerd.toml",
+		"/etc/containerd/config.toml",
+		"/usr/local/etc/containerd/config.toml",
+	}
+
+	defaultDataRoot = "/var/lib/containerd"
+)
+
+type containerdConfig struct {
+	Root string `toml:"Root"`
+}
+
+// GetDataRoot returns the containerd data root directory, as read from
+// the containerd config file.
+func GetDataRoot() (string, error) {
+	for _, path := range configPath {
+		dataRoot, err := parseDataRoot(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", fmt.Errorf("failed to open file %s: %w", path, err)
+		}
+		return dataRoot, nil
+	}
+	return defaultDataRoot, nil
+}
+
+func parseDataRoot(path string) (string, error) {
+	var config containerdConfig
+
+	// open the config file; if it does not exist, move on to the next one.
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	// parse the "root"
+	if _, err := toml.NewDecoder(f).Decode(&config); err != nil {
+		return "", fmt.Errorf("could not decode %s: %w", path, err)
+	}
+
+	// if no "root" present, assume it's the default
+	if config.Root == "" {
+		return defaultDataRoot, nil
+	}
+
+	return config.Root, nil
+}

--- a/containerdUtils/containerdUtils_test.go
+++ b/containerdUtils/containerdUtils_test.go
@@ -1,0 +1,106 @@
+package containerdUtils
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestGetDataRoot(t *testing.T) {
+	tests := []struct {
+		name           string
+		configPath     string
+		configContent  string
+		expectedRoot   string
+		expectError    bool
+	}{
+		{
+			name: "Config with root entry",
+			configPath: "/etc/containerd/containerd.toml",
+			configContent: `
+version = 2
+
+root = "/var/lib/desktop-containerd/daemon"
+state = "/run/containerd"
+
+oom_score = 0
+imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "k8s.gcr.io/pause:3.2"
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    root_path = "/var/lib/containerd/snapshotter"
+`,
+			expectedRoot: "/var/lib/desktop-containerd/daemon",
+			expectError:  false,
+		},
+		{
+			name: "Config without root entry",
+			configPath: "/etc/containerd/config.toml",
+			configContent: `
+version = 2
+
+state = "/run/containerd"
+oom_score = 0
+imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "k8s.gcr.io/pause:3.2"
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    root_path = "/var/lib/containerd/snapshotter"
+`,
+			expectedRoot: "/var/lib/containerd", // Default path
+			expectError:  false,
+		},
+		{
+			name:         "Nonexistent config file",
+			configPath:   "/path/to/nowhere",
+			expectedRoot: "",
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var configPath string
+			var err error
+
+			// Create a temporary config file if content is provided
+			if tt.configContent != "" {
+				tmpFile, err := ioutil.TempFile("", "config-*.toml")
+				if err != nil {
+					t.Fatalf("Failed to create temp file: %v", err)
+				}
+				defer os.Remove(tmpFile.Name()) // Clean up after test
+
+				// Write the content
+				configPath = tmpFile.Name()
+				if _, err = tmpFile.WriteString(tt.configContent); err != nil {
+					t.Fatalf("Failed to write to temp file: %v", err)
+				}
+				tmpFile.Close()
+			} else {
+				configPath = "/nonexistent/config.toml"
+			}
+
+			root, err := parseDataRoot(configPath)
+
+			// Check if an error was expected or not
+			if tt.expectError && err == nil {
+				t.Fatalf("Expected error: %v, got: %v", tt.expectError, err)
+			}
+
+			// Check the expected root path if no error was expected
+			if !tt.expectError && root != tt.expectedRoot {
+				t.Fatalf("Expected root: %s, got: %s", tt.expectedRoot, root)
+			}
+		})
+	}
+}

--- a/containerdUtils/go.mod
+++ b/containerdUtils/go.mod
@@ -1,0 +1,5 @@
+module github.com/nestybox/sysbox-libs/containerdUtils
+
+go 1.21.3
+
+require github.com/BurntSushi/toml v1.4.0

--- a/containerdUtils/go.sum
+++ b/containerdUtils/go.sum
@@ -1,0 +1,2 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=


### PR DESCRIPTION
Add the containerdUtils package to the sysbox-libs. Used by Sysbox Enterprise in Docker Desktop.

Bonus: small fix in `capability/capability_test.go` to ensure unit tests pass.