### PR TITLE
Fix bug in shiftfs checker.

### DIFF
--- a/shiftfs/shiftfs.go
+++ b/shiftfs/shiftfs.go
@@ -136,10 +136,6 @@ func runShiftfsCheckOnHost(dir string, checkOnOverlayfs bool) (bool, error) {
 		return false, err
 	}
 
-	if err := os.Chown(testDir, usernsUid, usernsUid); err != nil {
-		return false, err
-	}
-
 	logrus.Debugf("- shiftfs check: test dir = %s (%s)", testDir, fsName)
 
 	if checkOnOverlayfs {


### PR DESCRIPTION
There's a bug in the shiftfs checker that is causing it report false negatives (i.e., it believes shiftfs is not working in hosts where it actually is working).

The bug was that shiftfs checker was creating a test dir where shiftfs will be mounted, and chowning that dir to the user-ns mapped uid:gid. However that dir must not be chowned, since the shiftfs mount on it already ensures that root in the user-ns will be able to access it. In fact by chowning it we are causing shiftfs to not work properly on it.

Fixes https://github.com/nestybox/sysbox/issues/922.